### PR TITLE
Proposed changes in GCC ML training schedule

### DIFF
--- a/training_sessions_science.yaml
+++ b/training_sessions_science.yaml
@@ -958,31 +958,11 @@ machinelearning:
   description:
   sessions:
     - name: "Introduction to Machine Learning"
-      speaker: khanteymoori
-      video:
-        link:
-        length:
-        captions:
-
-    - name: "Introduction to Deep Learning"
-      speaker: khanteymoori
-      video:
-        link:
-        length:
-        captions:
-      material:
-        - type: tutorial
-          link: topics/statistics/tutorials/intro_deep_learning/tutorial.html
-
-    - name: "Clustering in Machine Learning"
       speaker: anuprulez
       video:
         link:
         length:
         captions:
-      material:
-        - type: tutorial
-          link: topics/statistics/tutorials/clustering_machinelearning/tutorial.html
 
     - name: "Classification in Machine Learning"
       speaker: anuprulez
@@ -996,7 +976,7 @@ machinelearning:
           link: topics/statistics/tutorials/classification_machinelearning/tutorial.html
 
     - name: "Regression in Machine Learning"
-      speaker: khanteymoori
+      speaker: anuprulez
       video:
         link:
         length:


### PR DESCRIPTION
A few minor changes to the GCC ML training schedule:

@anuprulez will cover the following topics:

- Introduction to ML
- Classification in ML
- Regression in ML

Topics excluded:

- Clustering in ML
- Introduction to deep learning (there is a separate training series for deep learning, some introductory concepts would anyways be discussed)

Thanks!!